### PR TITLE
define handlers as interceptors rather than fns

### DIFF
--- a/src/geheimtur/impl/form_based.clj
+++ b/src/geheimtur/impl/form_based.clj
@@ -1,7 +1,8 @@
 (ns geheimtur.impl.form-based
   (:require [geheimtur.util.auth :refer [authenticate logout]]
             [geheimtur.util.response :as response]
-            [geheimtur.util.url :as url]))
+            [geheimtur.util.url :as url]
+            [io.pedestal.interceptor.helpers :as h]))
 
 (defn- default-form-reader
   [form]
@@ -21,22 +22,26 @@
            login-uri         "/login"
            redirect-on-login true}
     :as   config}]
-  (fn [{:keys [form-params query-params] :as request}]
-    (let [return-url          (when redirect-on-login (or (:return form-params)
-                                                          (:return query-params)))
-          [username password] (form-reader form-params)]
-      (if-let [identity (and username password (credential-fn username password))]
-        (authenticate
-         (response/redirect-after-post (if (and return-url
-                                                (url/relative? return-url))
-                                         return-url "/"))
-         identity)
-        (let [redirect-url (if return-url
-                             (str login-uri "?error=true&return=" return-url)
-                             (str login-uri "?error=true"))]
-          (response/redirect-after-post redirect-url))))))
+  (h/handler
+   ::default-login-handler
+   (fn [{:keys [form-params query-params] :as request}]
+     (let [return-url          (when redirect-on-login (or (:return form-params)
+                                                           (:return query-params)))
+           [username password] (form-reader form-params)]
+       (if-let [identity (and username password (credential-fn username password))]
+         (authenticate
+          (response/redirect-after-post (if (and return-url
+                                                 (url/relative? return-url))
+                                          return-url "/"))
+          identity)
+         (let [redirect-url (if return-url
+                              (str login-uri "?error=true&return=" return-url)
+                              (str login-uri "?error=true"))]
+           (response/redirect-after-post redirect-url)))))))
 
-(defn default-logout-handler
+(def default-logout-handler
   "Returns a Ring response that redirects to / and unsets identity associated with corrent session."
-  [request]
-  (logout (response/redirect-after-post "/")))
+  (h/handler
+   ::default-logout-handler
+   (fn [request]
+     (logout (response/redirect-after-post "/")))))

--- a/test/geheimtur/impl/form_based_test.clj
+++ b/test/geheimtur/impl/form_based_test.clj
@@ -1,40 +1,43 @@
 (ns geheimtur.impl.form-based-test
-  (:require [clojure.test :refer :all ]
-            [geheimtur.impl.form-based :refer :all ]
+  (:require [clojure.test :refer :all]
+            [geheimtur.impl.form-based :refer :all]
             [geheimtur.util.auth :as auth]))
 
 (deftest default-login-handler-test
-  (let [handler (default-login-handler {})]
+  (let [{handler :enter} (default-login-handler {})]
     (testing "Redirects to login page on error"
-      (let [response (handler {})]
-        (is (not (nil? response)))
+      (let [{response :response}  (handler {:request {}})]
         (is (= 303 (:status response)))
         (is (= "/login?error=true" (get-in response [:headers "Location"])))))
 
     (testing "Redirects to login page on error without loosing return url"
-      (let [response (handler {:query-params {:return "/some-url"}})]
-        (is (not (nil? response)))
+      (let [{response :response} (handler {:request {:query-params {:return "/some-url"}}})]
         (is (= 303 (:status response)))
         (is (= "/login?error=true&return=/some-url" (get-in response [:headers "Location"]))))))
 
-  (let [handler (default-login-handler {:credential-fn (fn [user password]
-                                                            (when (and (= user "user")
-                                                                       (= password "password"))
-                                                              :success))})]
+  (let [{handler :enter}
+        (default-login-handler
+          {:credential-fn (fn [user password]
+                            (and (= user "user")
+                                 (= password "password")
+                                 :success))})]
     (testing "Redirects on success to return url"
-      (let [response (handler {:form-params  {"username" "user" "password" "password"}
-                               :query-params {:return "/redirect"}})]
+      (let [{response :response}
+            (handler {:request {:form-params  {"username" "user" "password" "password"}
+                                :query-params {:return "/redirect"}}})]
         (is (= 303 (:status response)))
         (is (= "/redirect" (get-in response [:headers "Location"])))))
 
     (testing "Ignores absolute return urls"
-      (let [response (handler {:form-params  {"username" "user" "password" "password"}
-                               :query-params {:return "http://evil.com"}})]
+      (let [{response :response}
+            (handler {:request {:form-params  {"username" "user" "password" "password"}
+                                :query-params {:return "http://evil.com"}}})]
         (is (= 303 (:status response)))
         (is (= "/" (get-in response [:headers "Location"])))))))
 
 (deftest default-logout-handler-test
-  (let [response (default-logout-handler {})]
+  (let [{handler :enter} default-logout-handler
+        {response :response} (handler {:request {}})]
     (is (= 303 (:status response)))
     (is (= "/" (get-in response [:headers "Location"])))
     (is (nil? (get-in response [:session ::auth/identity] :not-found)))))


### PR DESCRIPTION
rewrite fn handlers as interceptors, allowing routes to be written as

```clj
["/login" {:get (authenticate-handler @providers)}]
```

rather than
```clj
(def oath-handler
  (authenticate-handler providers))

["/oauth.login" {:get oath-handler}]
```