### PR TITLE
added client-params to the auth handler

### DIFF
--- a/src/geheimtur/impl/oauth2.clj
+++ b/src/geheimtur/impl/oauth2.clj
@@ -49,12 +49,12 @@
    (fn [req]
      (let [{:keys [query-params] :as request} req]
        (when-let [provider (:provider query-params)]
-         (when-let [{:keys [auth-url client-id scope callback-uri]} (get providers (keyword provider))]
+         (when-let [{:keys [auth-url client-id scope callback-uri client-params]} (get providers (keyword provider))]
            (let [token (create-afs-token)
-                 query {:client_id     client-id
-                        :response_type "code"
-                        :scope         scope
-                        :state         token}
+                 query (merge client-params {:client_id     client-id
+                                             :response_type "code"
+                                             :scope         scope
+                                             :state         token})
                  query (if callback-uri
                          (assoc query :redirect_uri callback-uri)
                          query)

--- a/test/geheimtur/impl/oauth2_test.clj
+++ b/test/geheimtur/impl/oauth2_test.clj
@@ -27,6 +27,13 @@
     (let [{handler :enter} (authenticate-handler {})]
       (is (nil? (:response (handler {:request {:query-params {}}}))))
       (is (nil? (:response (handler {:request {:query-params {:provider "github"}}}))))))
+
+  (testing "successfully merges client-params map into request params"
+    (let [client-params-provider (assoc-in providers [:github :client-params] {:foo "bar"})
+          {handler :enter} (authenticate-handler client-params-provider)
+          m (handler {:request {:query-params {:provider "github" :return "/return"}}})
+          location (-> m :response :headers (get "Location"))]
+      (is (re-find #"foo=bar" location))))
   
   (testing "Successfuly redirects and stores state in the session"
     (let [{handler :enter} (authenticate-handler providers)


### PR DESCRIPTION
I added a top level parameter to the auth-handler that allows us to pass any additional client params to the client-side oauth request. It was specifically to address the following issue: https://github.com/propan/geheimtur/issues/17 

Also apologies for the original PR. I unintentionally carried over some superfluous commits. Made sure to squash them this time.