### PR TITLE
Custom State Generation and Checking

### DIFF
--- a/src/geheimtur/impl/oauth2.clj
+++ b/src/geheimtur/impl/oauth2.clj
@@ -40,6 +40,7 @@
 
   The following keys in provider's configuration are optional:
       :client-params      - a map of extra query parameters to be included in the authorization request
+      :create-state-fn    - a function that accepts the authentication request and returns a state token.
       :token-parse-fn     - a function that accepts the token endpoint response and returns a map with the parsed
                             OAuth2 token response. The successfuly parsed response must have at least :access_token key.
       :user-info-url      - if defined, will be used to get user's details after successful access token acquisition


### PR DESCRIPTION
This PR adds two new optional keys to provider specs:
* `:create-state-fn` is a function that generates a custom state value, given the request as an argument. This is useful when you want to generate your own pseudorandom value, JWT/S/E etc.
* `:check-state-fn` is a predicate function that checks the state value against the one stored in the session. It is given the pedestal context as it's first arg to maximize flexibility. This could be used to do additional verification on the values (such as a JWT unsign/claim verification), or in cases where a trust relationship exists with the OAuth provider, disabled by setting the key to `(constantly true)`.
Thanks again for the awesome lib!