### PR TITLE
Add support for query params in auth-url

### DIFF
--- a/src/geheimtur/impl/oauth2.clj
+++ b/src/geheimtur/impl/oauth2.clj
@@ -1,7 +1,6 @@
 (ns geheimtur.impl.oauth2
   (:require [clj-http.client :as client]
             [clojure.walk :refer [keywordize-keys]]
-            [clojure.string :as str]
             [geheimtur.util.response :as response]
             [geheimtur.util.auth :refer [authenticate]]
             [io.pedestal.log :as log]

--- a/src/geheimtur/impl/oauth2.clj
+++ b/src/geheimtur/impl/oauth2.clj
@@ -20,7 +20,7 @@
   [url query]
   (->> query
        ring-codec/form-encode
-       (str url (if (str/includes? url "?") "&" "?"))))
+       (str url (if (-> url .toString (.contains "?")) "&" "?"))))
 
 (defn authenticate-handler
   "Creates a handler that redirects users to OAuth2 service providers using a providers configuration map or a function.

--- a/src/geheimtur/impl/oauth2.clj
+++ b/src/geheimtur/impl/oauth2.clj
@@ -1,6 +1,7 @@
 (ns geheimtur.impl.oauth2
   (:require [clj-http.client :as client]
             [clojure.walk :refer [keywordize-keys]]
+            [clojure.string :as str]
             [geheimtur.util.response :as response]
             [geheimtur.util.auth :refer [authenticate]]
             [io.pedestal.log :as log]
@@ -19,7 +20,7 @@
   [url query]
   (->> query
        ring-codec/form-encode
-       (str url "?")))
+       (str url (if (str/includes? url "?") "&" "?"))))
 
 (defn authenticate-handler
   "Creates a handler that redirects users to OAuth2 service providers using a providers configuration map or a function.

--- a/test/geheimtur/impl/oauth2_test.clj
+++ b/test/geheimtur/impl/oauth2_test.clj
@@ -30,7 +30,7 @@
                                            (= access-token "token-token"))
                                       :success))}})
 
-(defn- assoc-in-ps 
+(defn- assoc-in-ps
   [ps ks v]
   (if (fn? ps)
     (fn [] (assoc-in (ps) ks v))
@@ -40,7 +40,11 @@
   (let [url "http://domain.com"]
     (are [result query] (= result (create-url url query))
       (str url "?")        {}
-      (str url "?a=b&c=d") (sorted-map :a "b" :c "d"))))
+      (str url "?a=b&c=d") (sorted-map :a "b" :c "d")))
+  (let [url "http://domain.com?partner_id=abacaba"]
+    (are [result query] (= result (create-url url query))
+      (str url "&")        {}
+      (str url "&a=b&c=d") (sorted-map :a "b" :c "d"))))
 
 (defn authenticate-handler-with-providers
   [label providers]
@@ -80,7 +84,7 @@
                   :scope         "user:email"
                   :redirect_uri  "/oauth.callback"} query)))))
 
-    (testing "stores custom state in the session" 
+    (testing "stores custom state in the session"
       (let [providers            (assoc-in-ps providers [:github :create-state-fn] (constantly "foo"))
             {handler :enter}     (authenticate-handler providers)
             {response :response} (handler {:request {:query-params {:provider "github" :return "/return"}}})


### PR DESCRIPTION
In our project `:auth-URL` contains a query parameter, which interferes with appending extra query parameters with just `?`.

I've added a check that picks '&' instead and covered it with the test.

I hope this is according to the code style and added to the right place.